### PR TITLE
Remove deletion routes for sensors, ra, sa

### DIFF
--- a/app/server/models/schedules.py
+++ b/app/server/models/schedules.py
@@ -17,7 +17,7 @@ class SAS(BaseModel):
 
 
 class RAS(BaseModel):
-    RAS_id: PyObjectId
+    RA_id: PyObjectId
     interval: float = Field(gt=0, description="Checking Period")
     threshold: float = Field(gt=0, description="Threshold ActivationValue")
     duration: float = Field(gt=0, description="How long to Actuate for")

--- a/app/server/routes/garden.py
+++ b/app/server/routes/garden.py
@@ -3,7 +3,7 @@ from dotenv import load_dotenv
 from fastapi import APIRouter, Body, status, HTTPException
 from fastapi.encoders import jsonable_encoder
 from typing import List
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 from server.models.garden import GardenModel, UpdateGardenModel
 from server.database import db
 

--- a/app/server/routes/garden.py
+++ b/app/server/routes/garden.py
@@ -59,13 +59,3 @@ async def update_garden(id: str, garden: UpdateGardenModel = Body(...)):
         return existing_garden
 
     raise HTTPException(status_code=404, detail=f"Garden {id} not found")
-
-
-@router.delete("/{id}", response_description="Delete a garden")
-async def delete_garden(id: str):
-    delete_result = await db["gardens"].delete_one({"_id": id})
-
-    if delete_result.deleted_count == 1:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-    raise HTTPException(status_code=404, detail=f"Garden {id} not found")

--- a/app/server/routes/sensor.py
+++ b/app/server/routes/sensor.py
@@ -60,13 +60,3 @@ async def update_sensor(id: str, sensor: UpdateSensorModel = Body(...)):
         return existing_sensor
 
     raise HTTPException(status_code=404, detail=f"Sensor {id} not found")
-
-
-@router.delete("/{id}", response_description="Delete a sensor")
-async def delete_sensor(id: str):
-    delete_result = await db["sensors"].delete_one({"_id": id})
-
-    if delete_result.deleted_count == 1:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-    raise HTTPException(status_code=404, detail=f"Sensor {id} not found")

--- a/app/server/routes/sensor.py
+++ b/app/server/routes/sensor.py
@@ -5,7 +5,7 @@ from fastapi.encoders import jsonable_encoder
 
 
 from dotenv import load_dotenv
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 from server.models.sensor import SensorModel, UpdateSensorModel
 from server.database import db
 from typing import List


### PR DESCRIPTION
To prevent invalid logs we do not want to delete sensors, ra or sa. This also fixed a small typo in schedules.