### PR TITLE
Add local mongo db to workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,9 +2,9 @@ name: pytest
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
@@ -16,26 +16,26 @@ env:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-    # environment: Hydroapi-env
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.*') }}
-        restore-keys: | 
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt        
-    - name: Run pytest
-      run: | 
-        pytest
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.*') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Create mongoDB Docker container
+        run: sudo docker run -d -p 27017:27017 mongo:latest
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: |
+          pytest

--- a/App/server/tests/test_gardens.py
+++ b/App/server/tests/test_gardens.py
@@ -21,7 +21,10 @@ app.include_router(garden_router, tags=["gardens"], prefix="/garden")
 
 @app.on_event("startup")
 async def startup_event():
-    app.mongodb_client = MongoClient(os.environ["ATLAS_URI"])
+    if os.environ["ATLAS_URI"]:
+        app.mongodb_client = MongoClient(os.environ["ATLAS_URI"])
+    else:
+        app.mongodb_client = MongoClient()
     app.database = app.mongodb_client[os.environ["DB_NAME"] + "test"]
 
 

--- a/App/server/tests/test_scheduled_actuator.py
+++ b/App/server/tests/test_scheduled_actuator.py
@@ -20,7 +20,10 @@ app.include_router(sa_router, tags=["scheduled_actuators"], prefix="/sa")
 
 @app.on_event("startup")
 async def startup_event():
-    app.mongodb_client = MongoClient(os.environ["ATLAS_URI"])
+    if os.environ["ATLAS_URI"]:
+        app.mongodb_client = MongoClient(os.environ["ATLAS_URI"])
+    else:
+        app.mongodb_client = MongoClient()
     app.database = app.mongodb_client[os.environ["DB_NAME"] + "test"]
 
 

--- a/App/server/tests/test_sensors.py
+++ b/App/server/tests/test_sensors.py
@@ -30,7 +30,10 @@ app.include_router(garden_router, tags=["garden"], prefix="/garden")
 
 @app.on_event("startup")
 async def startup_event():
-    app.mongodb_client = MongoClient(os.environ["ATLAS_URI"])
+    if os.environ["ATLAS_URI"]:
+        app.mongodb_client = MongoClient(os.environ["ATLAS_URI"])
+    else:
+        app.mongodb_client = MongoClient()
     app.database = app.mongodb_client[os.environ["DB_NAME"] + "test"]
 
 


### PR DESCRIPTION
Instead of connecting to a hosted mongo db instance and running the tests, we can spin up a local mongo db server and run the tests against them. This makes the tests run much faster and is better practice.