### PR TITLE
Add ref_id to commands

### DIFF
--- a/app/models/command.py
+++ b/app/models/command.py
@@ -7,6 +7,7 @@ import pytz
 
 class Command(BaseModel):
     id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    ref_id: str = Field(...)
     cmd: int = Field(...)
     type: str = Field(...)
     garden_id: str = Field(...)
@@ -18,6 +19,7 @@ class Command(BaseModel):
         schema_extra = {
             "example": {
                 "_id": "66608a32-a24c-4b70-ae2c-c46c586ea0c3",
+                "ref_id": "36708a32-a24c-4b70-ae2c-c46c586ea0c3",
                 "cmd": 1,
                 "type": "reactive actuator",
                 "garden_id": "87808a32-a24c-4b70-ae2c-c46c586ea0c3",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,10 +5,10 @@ from fastapi.testclient import TestClient
 from pymongo import MongoClient
 from dotenv import load_dotenv
 
+from app.routes.command import router as command_router
+
 load_dotenv()
 
-
-from app.routes.command import router as command_router
 
 app = FastAPI()
 app.include_router(command_router, tags=["commands"], prefix="/cmd")
@@ -32,7 +32,15 @@ async def shutdown_event():
 def test_create_command():
     with TestClient(app) as client:
         response = client.post(
-            "/cmd/", json=[{"cmd": 1, "type": "reactive actuator", "garden_id": "abc"}]
+            "/cmd/",
+            json=[
+                {
+                    "ref_id": "btnrj",
+                    "cmd": 1,
+                    "type": "reactive actuator",
+                    "garden_id": "abc",
+                }
+            ],
         )
         assert response.status_code == 201
 
@@ -52,7 +60,15 @@ def test_create_command_missing_field():
 def test_get_cmd():
     with TestClient(app) as client:
         new_cmd = client.post(
-            "/cmd/", json=[{"cmd": 1, "type": "reactive actuator", "garden_id": "abc"}]
+            "/cmd/",
+            json=[
+                {
+                    "ref_id": "hsdjfsk",
+                    "cmd": 1,
+                    "type": "reactive actuator",
+                    "garden_id": "abc",
+                }
+            ],
         ).json()[0]
         get_cmd_response = client.get("/cmd/" + new_cmd.get("_id"))
         assert get_cmd_response.status_code == 200


### PR DESCRIPTION
ref_id will be used to link the command to a specific actuator id or sensor id. Without this we have no way of knowing what the command is referring to.